### PR TITLE
feat: integrate next-auth authentication

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import AuthProvider from "@/components/AuthProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { signIn, signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+
+export default function LoginPage() {
+  const { data: session } = useSession();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  if (session) {
+    return (
+      <div className="p-4">
+        <p>Conectado como {session.user?.email}</p>
+        <button onClick={() => signOut()}>Sair</button>
+      </div>
+    );
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    signIn("credentials", { email, password });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-2 text-xl">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="btn">
+          Entrar
+        </button>
+      </form>
+      <button onClick={() => signIn("google")} className="btn">
+        Entrar com Google
+      </button>
+    </div>
+  );
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { signIn, signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+
+export default function RegisterPage() {
+  const { data: session } = useSession();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  if (session) {
+    return (
+      <div className="p-4">
+        <p>Conectado como {session.user?.email}</p>
+        <button onClick={() => signOut()}>Sair</button>
+      </div>
+    );
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: enviar dados para registro real
+    signIn("credentials", { email, password });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-2 text-xl">Registro</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="btn">
+          Registrar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { ReactNode } from "react";
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "next-auth": "^4.24.5",
     "react-konva": "^19.0.7",
     "use-image": "^1.1.4"
   },

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,30 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const { email, password } = credentials ?? {};
+        if (!email || !password) {
+          return null;
+        }
+        // TODO: replace with real user lookup
+        return { id: email, email };
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+};
+
+export default NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- install next-auth and add Google & credentials providers
- add login and registration pages using signIn/signOut
- wrap app with SessionProvider for auth context

## Testing
- `npm run lint` *(fails: Key "@typescript-eslint/indent" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb711b1a90832a9ae56634a0bb8f84