### PR TITLE
feat: add user registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # Ignore Windows Zone Identifier files
 *:Zone.Identifier
+
+# Prisma SQLite database
+prisma/dev.db

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+function isValidEmail(email: string) {
+  return /\S+@\S+\.\S+/.test(email);
+}
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+
+  if (
+    typeof email !== 'string' ||
+    typeof password !== 'string' ||
+    !isValidEmail(email) ||
+    password.length < 6
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid email or password' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const user = await prisma.user.create({
+      data: { email, password },
+    });
+    return NextResponse.json({ id: user.id });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'User creation failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (res.ok) {
+      router.push('/login');
+    } else {
+      const data = await res.json();
+      setError(data.error ?? 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Register</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-2"
+          required
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white p-2">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({});
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-konva": "^19.0.7",
-    "use-image": "^1.1.4"
+    "use-image": "^1.1.4",
+    "@prisma/client": "^5.22.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -30,6 +31,7 @@
     "prettier": "3.6.2",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "typescript-eslint": "^8.40.0"
+    "typescript-eslint": "^8.40.0",
+    "prisma": "^5.22.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add registration page with email/password form
- create API route to validate and persist new users via Prisma
- initialize Prisma schema and client

## Testing
- `npm install` *(fails: 403 Forbidden for @prisma/client)*
- `npx prisma generate` *(fails: 403 Forbidden for prisma)*
- `npm run lint` *(fails: Could not find "indent" in plugin "@typescript-eslint"; ESLint config issue)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71144fd0832aad5103c5bdb5d1e8